### PR TITLE
Correct wrong password for installation

### DIFF
--- a/ads.dat
+++ b/ads.dat
@@ -1,5 +1,5 @@
 user=admin
-pass=ads
+pass=2deb000b57bfac9d72c14d4ed967b572
 click_url=/ads/click.php
 js_url=/ads/js.php
 target=_blank


### PR DESCRIPTION
Password stored in .dat file in plaintext, comparison in code checks against an MD5'd version.

Updated dat file to contain MD5'd text of "ads" to match install documentation.
